### PR TITLE
Make unit spacing coherent

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -877,8 +877,8 @@
 										<td id="registration" onclick="sortByRegistration();">Registration</td>
 										<td id="aircraft_type" onclick="sortByAircraftType();">Type</td>
 										<td id="squawk" onclick="sortBySquawk();">Squawk</td>
-										<td id="altitude" onclick="sortByAltitude();">Altitude(<span class="altitudeUnit"></span>)</td>
-										<td id="speed" onclick="sortBySpeed();">GS(<span class="speedUnit"></span>)</td>
+										<td id="altitude" onclick="sortByAltitude();">Altitude (<span class="altitudeUnit"></span>)</td>
+										<td id="speed" onclick="sortBySpeed();">GS (<span class="speedUnit"></span>)</td>
 										<td id="vert_rate" onclick="sortByVerticalRate();">V. Rate (<span class="verticalRateUnit"></span>)</td>
 										<td id="distance" onclick="sortByDistance();">Dist. (<span class="distanceUnit"></span>)</td>
 										<td id="track" onclick="sortByTrack();">Heading</td>


### PR DESCRIPTION
Correct: Dist. (km) -- one blank space present
Right now: GS(km/h) -- no space