### PR TITLE
Change if statement for $SRC_DIR

### DIFF
--- a/tar1090.sh
+++ b/tar1090.sh
@@ -13,7 +13,7 @@ if ! [[ -d $RUN_DIR ]]; then
     echo "runtime directory (first argument: $RUN_DIR) is not a directory, fatal error!"
     exit 1
 fi
-if ! [[ -z $SRC_DIR ]]; then
+if ! [[ -d $SRC_DIR ]]; then
     echo "source directory (2nd argument) not specified, fatal error!"
     exit 1
 fi


### PR DESCRIPTION
I was having an issue where tar1090 would output "source directory (2nd argument) not specified, fatal error!" when the 2nd argument was given, and was a directory.

Changing the if statement as-per the commit 462c855 seems to have solved this.

The original behaviour (displaying the error and exiting if the user does not provide the 2nd argument) still works.

One futher change could be adjusting the error message to something like "`source directory (2nd argument) not specified or does not exist, fatal error!`", however I will leave this up to you.

Thanks!