### PR TITLE
Update CARTO Basemaps url to use correct subdomains

### DIFF
--- a/html/layers.js
+++ b/html/layers.js
@@ -108,7 +108,7 @@ function createBaseLayers() {
 
         world.push(new ol.layer.Tile({
             source: new ol.source.OSM({
-                "url" : "https://{a-z}.basemaps.cartocdn.com/"+ basemap_id + "/{z}/{x}/{y}.png",
+                "url" : "https://{a-d}.basemaps.cartocdn.com/"+ basemap_id + "/{z}/{x}/{y}.png",
                 "attributions" : 'Courtesy of <a href="https://carto.com">CARTO.com</a>'
                 + ' using data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://www.openstreetmap.org/copyright">ODbL</a>.',
             }),


### PR DESCRIPTION
The correct subdomains for CARTO Basemaps are `a-d` and although, currently, `e-z` subdomains work they are going to be removed soon.