### PR TITLE
Add a setting to persist filters to local storage.

### DIFF
--- a/README-query.md
+++ b/README-query.md
@@ -14,6 +14,15 @@
 - noIsolation - show other planes and not only the ones selected by ?icao
 - icaoFilter=hex1,hex2,hex3 - Only show the mentioned hex ids, no other aircraft will ever be displayed
 - reg=registration - Direct link to specific aircraft registration(s). Separate multiple with commas. ?icao is preferred as this option takes longer to load.
+- filterAltMin=500 - filter minimum altitute to 500ft
+- filterAltMax=5000 - filter maximum altitute to 5000ft
+- filterCallSign=^(UAL|DAL) - filter callsign to United or Deleta
+- filterType=B738 - filter to aircraft type B738 aka 737-800
+- filterDescription=L2J - filter aircraft by description
+- filterIcao=^a - filter icao that start with a
+- filterSources=adsb,uat,adsr,mlat,tisb,modeS - filter palnes by source type.
+- filterDbFlag=military,pia,ladd - filter planes by the db flags.
+
 
 ## Troubleshooting
 

--- a/html/early.js
+++ b/html/early.js
@@ -61,6 +61,14 @@ try {
             if (isNaN(val)) return null;
             return val;
         },
+        getInt: function(s)  {
+            if (!this.params.has(s.toLowerCase())) return null;
+            const param =  this.params.get(s.toLowerCase());
+            if (!param) return null;
+            const val = parseInt(param, 10);
+            if (isNaN(val)) return null;
+            return val;
+        }
     };
     const inputParams = new URLSearchParams(window.location.search);
     for (const [k, v] of inputParams) {


### PR DESCRIPTION
This will add a setting (disabled by default) to persist the filters to local storage.  

This should resolve #14

I tested with all tracks enabled and then enabled a filter and it cleared all non selected plans that don't match.