### PR TITLE
UI/UE: Make current toggle button state more obvious.

### DIFF
--- a/html/style.css
+++ b/html/style.css
@@ -476,10 +476,10 @@ select.error, textarea.error, input.error {
 }
 
 .activeButton {
- color:#000
+ color:#9D9
 }
 .inActiveButton {
- color:#fff
+ color:#D99
 }
 
 .settingsCog {


### PR DESCRIPTION
Using *tar1090* as the public ADSBx frontend for quite some time, I still would not learn to intuitively determine the current state of the various toggle buttons (i.e. ”LOKMPIRF“). Bright white signaling an *off* state while a black button is *active* might confuse other users, too, I assume. (The current approach isn't a convincing ”dark cockpit“ comparison, eiher.)
| before | after |
| -- | --- |
| ![image](https://user-images.githubusercontent.com/673619/151155692-0109a475-f2fa-4bba-940c-a1e38f3fd42f.png) | ![image](https://user-images.githubusercontent.com/673619/151155781-c5521f9d-d5ed-4641-b48d-e121052ae2e0.png) |

<details>
<summary>Of course you can always resort to a user style on desktop instead of improving upstream:</summary>

```
@-moz-document domain("globe.adsbexchange.com") {
.button.activeButton {
    color: #9D9;
}

.button.inActiveButton {
    color: #D99;
}

}

```
</details>