### PR TITLE
fix api url for planetspotters.net

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -2714,15 +2714,8 @@ function refreshPhoto(selected) {
     if (!selected.dbinfoLoaded) {
         displaySil();
         return;
-    } else if (false && selected.registration != null && selected.registration.match(/^[0-9]{0,2}\+?[0-9]{0,2}$/)) {
-        urlTail = '/hex/' + selected.icao.toUpperCase();
     } else if (selected.registration != null) {
-        urlTail = '/hex/' + selected.icao.toUpperCase() + '?reg=' + selected.registration;
-        const type = selected.icaoType;
-        // && type != 'E170' && !type.startsWith('E75')
-        if (type) {
-            urlTail += '&icaoType=' + type;
-        }
+        urlTail = '/reg/' + selected.registration;
         param = 'DB';
     } else {
         urlTail = 'hex/' + selected.icao.toUpperCase();


### PR DESCRIPTION
this fixes the planespotters.net images for planes which have no icao code in their database [but have images](https://www.planespotters.net/photo/1094764/7923-german-army-nhi-nh90-tth) like the [german military NH90 with registration 79+23](https://globe.adsbexchange.com/?icao=3f9e5b)