### PR TITLE
Speed is not displayed (dump1090-mutability)

### DIFF
--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -1430,7 +1430,7 @@ PlaneObject.prototype.updateData = function(now, last, data, init) {
     if (pTracks) {
         this.speed = Math.max(this.speed, gs);
     } else {
-        this.speed = gs;
+        this.speed = this.gs;
     }
 
     this.track = track;


### PR DESCRIPTION
I run tar1090 with dump1090-mutability and I have to apply this patch to show the speed in the airplane labels and the table on the right. This is related to the fix you've done for #111, but in my opinion this fix was incomplete.