### PR TITLE
Remove osm_adsbx background map

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -61,7 +61,6 @@
 // carto_dark_all
 // carto_dark_nolabels
 // gibs
-// osm_adsbx
 // chartbundle_sec: "Sectional Charts",
 // chartbundle_tac: "Terminal Area Charts",
 // chartbundle_hel: "Helicopter Charts",

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -58,7 +58,7 @@ let actual_range_outline_dash = null; // null - solid line, [5, 5] - dashed line
 let actual_range_show = true;
 
 // which map is displayed to new visitors
-let MapType_tar1090 = "osm_adsbx";
+let MapType_tar1090 = "osm";
 let defaultOverlays = [];
 let dwdLayers = 'dwd:RX-Produkt';
 

--- a/html/layers.js
+++ b/html/layers.js
@@ -63,18 +63,6 @@ function createBaseLayers() {
 
     world.push(new ol.layer.Tile({
         source: new ol.source.OSM({
-            "url" : "https://map.adsbexchange.com/mapproxy/tiles/1.0.0/osm/osm_grid/{z}/{x}/{y}.png",
-            attributionsCollapsible: false,
-            maxZoom: 16,
-            transition: tileTransition,
-        }),
-        name: 'osm_adsbx',
-        title: 'OpenStreetMap ADSBx',
-        type: 'base',
-    }));
-
-    world.push(new ol.layer.Tile({
-        source: new ol.source.OSM({
             maxZoom: 17,
             attributionsCollapsible: false,
             transition: tileTransition,

--- a/html/script.js
+++ b/html/script.js
@@ -2157,7 +2157,7 @@ function ol_map_init() {
         }
     });
     if (!foundType) {
-        MapType_tar1090 = "osm_adsbx";
+        MapType_tar1090 = "osm";
     }
 
     ol.control.LayerSwitcher.forEachRecursive(layers_group, function(lyr) {


### PR DESCRIPTION
Hi,
i would like to recommend to change the default background map of tar1090 from the AdsbExchange OpenStreetMap mirror to the normal OpenStreetMap tile servers. Further, i'd like to recommend to fully remove the osm_adsbx background map from tar1090.

My reasons for that proposal are:

* Due to the recent activities around adsbx, any implementations or dependencies should be reduced
* I heared about some DoS attacks or something against adsbx - understandable, but some friend told me, that their tar1090 background map is not loading properly (bad for UX)
* The adsbx OpenStreetMap mirror is using cloudflare, which is imho a no-go regarding to privacy and self-hosting stuff