### PR TITLE
Inconsistent title text for span `with_positions` 'With Position:' / 'With Positions:'

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -881,7 +881,7 @@
                       <td id="dump1090_message_rate_td"><span class="infoBlockTitleText">Messages:</span> <span id="dump1090_message_rate">n/a</span>/sec</td>
                     </tr>
                     <tr class="infoblock_body">
-                      <td style="width: 50%"><span id="with_positions" class="infoBlockTitleText">With Positions:</span> <span id="dump1090_total_ac_positions">n/a</span></td>
+                      <td style="width: 50%"><span id="with_positions" class="infoBlockTitleText">With Position:</span> <span id="dump1090_total_ac_positions">n/a</span></td>
                       <td id="dump1090_total_history_td"><span class="infoBlockTitleText">History:</span> <span id="dump1090_total_history">n/a</span> positions</td>
                     </tr>
                   </table>


### PR DESCRIPTION
I noticed that a title shown after toggling the 'V' button changes the title from plural to singular.

![image](https://user-images.githubusercontent.com/5631640/224433869-0e96392d-b1e3-425d-90e6-52235ba96804.png)

I chose to just change the initial title to be singular as the long form might be described as *count of aircraft with at least one position*.