### PR TITLE
Add route lookup via adsbdb.com

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -252,6 +252,7 @@ HideCols = [
 	"#icao",
 //	"#flag",
 //	"#flight",
+//     "#route",
 	"#registration",
 //	"#aircraft_type",
 //	"#squawk",
@@ -275,6 +276,9 @@ HideCols = [
 // planespottersAPI = true;
 // get pictures from planespotting.be
 // planespottingAPI = true;
+
+// get flight route from adsbdb.com
+// let adsbdbAPI = true;
 
 // show a link to jetphotos, only works if planespottersAPI is disabled
 // jetphotoLinks = false;

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -295,7 +295,7 @@ let planespottersAPI = true;
 let planespottingAPI = false;
 
 // get flight route from adsbdb.com
-let adsbdbAPI = true;
+let adsbdbAPI = false;
 
 // show a link to jetphotos, only works if planespottersAPI is disabled
 let jetphotoLinks = false;

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -268,6 +268,7 @@ let HideCols = [
 	"#icao",
 //	"#flag",
 //	"#flight",
+//     "#route",
 	"#registration",
 //	"#aircraft_type",
 //	"#squawk",
@@ -292,6 +293,9 @@ let showPictures = true;
 let planespottersAPI = true;
 // get pictures from planespotting.be
 let planespottingAPI = false;
+
+// get flight route from adsbdb.com
+let adsbdbAPI = true;
 
 // show a link to jetphotos, only works if planespottersAPI is disabled
 let jetphotoLinks = false;

--- a/html/index.html
+++ b/html/index.html
@@ -208,6 +208,16 @@
                   </div>
                 </td>
               </tr>
+              <tr id="routeRow" class="hidden">
+                <td>
+                  <div class="infoHeading">
+                    <span title="Reported flight origin and destination according to adsbdb.com">Route</span>:
+                  </div>
+                  <div class="infoData">
+                    <span id="selected_route"></span>
+                  </div>
+                </td>
+              </tr>
               <tr id="photoLinkRow" class="hidden">
                 <td>
                   <div class="infoHeading">
@@ -1022,6 +1032,7 @@
 
     <script>let databaseFolder = "db2";</script>
     <!-- JS_ANCHOR1 -->
+    <script src="https://unpkg.com/axios@1.1.2/dist/axios.min.js"></script>
     <script src="libs/jquery-3.6.1.min.js"></script>
     <script src="libs/elm-pep-01.js"></script>
     <script src="libs/jquery-ui-1.13.2.min.js"></script>

--- a/html/script.js
+++ b/html/script.js
@@ -7,6 +7,7 @@
 
 g.planes        = {};
 g.planesOrdered = [];
+g.route_cache = [];
 
 // Define our global variables
 let tabHidden = false;
@@ -1516,6 +1517,16 @@ jQuery('#selected_altitude_geom1')
             refreshSelected();
         }
     });
+    new Toggle({
+        key: "adsbdbAPI",
+        display: "Lookup route",
+        container: "#settingsRight",
+        init: adsbdbAPI,
+        setState: function(state) {
+            adsbdbAPI = state;
+        }
+    });
+
 
     new Toggle({
         key: "enableInfoblock",
@@ -3097,6 +3108,16 @@ function refreshSelected() {
         jQuery('#selected_squawk2').updateText(selected.squawk);
     }
 
+    if (adsbdbAPI) {
+        jQuery('#routeRow').show();
+        if (selected.routeString) {
+            jQuery('#selected_route').updateText(selected.routeString);
+        } else {
+            jQuery('#selected_route').updateText('n/a');
+        }
+    } else {
+        jQuery('#routeRow').hide();
+    }
     let magResult = null;
 
     if (geoMag && selected.position != null) {
@@ -3521,6 +3542,12 @@ function refreshFeatures() {
         },
         html: flightawareLinks,
         text: 'Callsign' };
+    cols.route = {
+        sort: function () { sortBy('route', compareAlpha, function(x) { return x.routeString }); },
+        value: function(plane) {
+            return ((adsbdbAPI && plane.routeString) || '');
+        },
+        text: 'Route' };
     cols.registration = {
         sort: function () { sortBy('registration', compareAlpha, function(x) { return x.registration; }); },
         value: function(plane) { return (flightawareLinks ? getFlightAwareIdentLink(plane.registration, plane.registration) : (plane.registration ? plane.registration : "")); },


### PR DESCRIPTION
This adds a rate limiting library and a reference to axios in order to easily and cleanly allow API accesses without exceeding the rate limits of the API provider. The way this was done might be a bit inconsistent given that for example jQuery is simply copied into this source base.

Once the app receives a callsign for a flight (and that is different from the registration - as asdbdb doesn't track 'live flight plans') it checks if there is already route information for this flight cached and if not it makes an API call to adsbdb.com to look up the origin and destination of that flight.

The code tries to be very careful not to run afoul of the rate limit of that free site - right now this is hopefully conservative enough that even people running a couple of different tar1090 instances won't get in trouble - but one can create a scenario where power users with many windows open might still end up with too many API requests.

As a workaround for people who intentionally keep many parallel instances open there is a config option to turn the route lookup off (right now it is turned on by default).