### PR TITLE
Add route lookup via a route API server

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -252,6 +252,7 @@ HideCols = [
 	"#icao",
 //	"#flag",
 //	"#flight",
+    "#route",
 	"#registration",
 //	"#aircraft_type",
 //	"#squawk",
@@ -275,6 +276,17 @@ HideCols = [
 // planespottersAPI = true;
 // get pictures from planespotting.be
 // planespottingAPI = true;
+
+// get flight route from routeApi service
+// useRouteAPI = false;
+// which routeApi service to use and whether to include lat/lng in the call
+// currently there appear to be two:
+// ADSBDB: routeApiUrl = "https://api.adsbdb.com/v0/callsign";
+// routeApiUrl = "https://api.adsb.lol/api/0/route";
+// routeApiAddLatLng = true; // set to false for adsbdb.com
+// rate limit to use: routeApiRequestsPerSlice requests per routeApiRequestSlice milliseconds
+// routeApiRequestsPerSlice = 30;
+// routeApiRequestSlice = 60000; // ms
 
 // show a link to jetphotos, only works if planespottersAPI is disabled
 // jetphotoLinks = false;

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -268,6 +268,7 @@ let HideCols = [
 	"#icao",
 //	"#flag",
 //	"#flight",
+//     "#route",
 	"#registration",
 //	"#aircraft_type",
 //	"#squawk",
@@ -292,6 +293,17 @@ let showPictures = true;
 let planespottersAPI = true;
 // get pictures from planespotting.be
 let planespottingAPI = false;
+
+// get flight route from routeApi service
+let useRouteAPI = false;
+// which routeApi service to use and whether to include lat/lng in the call
+// currently there appear to be two:
+// let routeApiUrl = "https://api.adsbdb.com/v0/callsign";
+let routeApiUrl = "https://api.adsb.lol/api/0/route";
+let routeApiAddLatLng = true; // set to false for adsbdb.com
+// rate limit to use: routeApiRequestsPerSlice requests per routeApiRequestSlice milliseconds
+let routeApiRequestsPerSlice = 30;
+let routeApiRequestSlice = 60000; // ms
 
 // show a link to jetphotos, only works if planespottersAPI is disabled
 let jetphotoLinks = false;

--- a/html/index.html
+++ b/html/index.html
@@ -208,6 +208,16 @@
                   </div>
                 </td>
               </tr>
+              <tr id="routeRow" class="hidden">
+                <td>
+                  <div class="infoHeading">
+                    <span title="Reported flight origin and destination according to adsbdb.com">Route</span>:
+                  </div>
+                  <div class="infoData">
+                    <span id="selected_route"></span>
+                  </div>
+                </td>
+              </tr>
               <tr id="photoLinkRow" class="hidden">
                 <td>
                   <div class="infoHeading">
@@ -1022,6 +1032,7 @@
 
     <script>let databaseFolder = "db2";</script>
     <!-- JS_ANCHOR1 -->
+    <script src="https://unpkg.com/axios@1.1.2/dist/axios.min.js"></script>
     <script src="libs/jquery-3.6.1.min.js"></script>
     <script src="libs/elm-pep-01.js"></script>
     <script src="libs/jquery-ui-1.13.2.min.js"></script>

--- a/html/script.js
+++ b/html/script.js
@@ -7,6 +7,7 @@
 
 g.planes        = {};
 g.planesOrdered = [];
+g.route_cache = [];
 
 // Define our global variables
 let tabHidden = false;
@@ -1516,6 +1517,16 @@ jQuery('#selected_altitude_geom1')
             refreshSelected();
         }
     });
+    new Toggle({
+        key: "useRouteAPI",
+        display: "Lookup route",
+        container: "#settingsRight",
+        init: useRouteAPI,
+        setState: function(state) {
+            useRouteAPI = state;
+        }
+    });
+
 
     new Toggle({
         key: "enableInfoblock",
@@ -3097,6 +3108,16 @@ function refreshSelected() {
         jQuery('#selected_squawk2').updateText(selected.squawk);
     }
 
+    if (useRouteAPI) {
+        jQuery('#routeRow').show();
+        if (selected.routeString) {
+            jQuery('#selected_route').updateText(selected.routeString);
+        } else {
+            jQuery('#selected_route').updateText('n/a');
+        }
+    } else {
+        jQuery('#routeRow').hide();
+    }
     let magResult = null;
 
     if (geoMag && selected.position != null) {
@@ -3521,6 +3542,12 @@ function refreshFeatures() {
         },
         html: flightawareLinks,
         text: 'Callsign' };
+    cols.route = {
+        sort: function () { sortBy('route', compareAlpha, function(x) { return x.routeString }); },
+        value: function(plane) {
+            return ((useRouteAPI && plane.routeString) || '');
+        },
+        text: 'Route' };
     cols.registration = {
         sort: function () { sortBy('registration', compareAlpha, function(x) { return x.registration; }); },
         value: function(plane) { return (flightawareLinks ? getFlightAwareIdentLink(plane.registration, plane.registration) : (plane.registration ? plane.registration : "")); },


### PR DESCRIPTION
So far there are two servers that I'm aware of that offer this API service: api.adsb.lol and adsbdb.com.
The api.adsb.lol code is open source and can also be run locally in a container. Either way, that code uses the VirtualRaderServer route data as published on GitHub, adsbdb uses its own, independently maintained data.

For use with remote servers like adsbdb.com this commit also adds a rate limiting library and a reference to axios in order to easily and cleanly allow API accesses without exceeding the rate limits of the API provider.

Once the app receives a callsign for a flight (and that is different from the registration - as none of the free providers track 'live flight plans'; they all only include information about scheduled flights), it checks if there is already route information for this flight cached and if not it makes an API call to look up the origin and destination of that flight.

If the API service is using the second generation API service that works with the VRS data, it also implements a (somewhat simplistic) plausibility check to ensure that obviously questionable route information isn't shown to the user (assuming the user enables passing lat/lng data to the server.

The code tries to be very careful not to run afoul of rate limits of route API sites - right now this is hopefully conservative enough that even people running a couple of different tar1090 instances won't get in trouble - but one can create a scenario where power users with many windows open might still end up with too many API requests. The number of requests and the corresponding time slice can be configured.