### PR TITLE
Add configuration for terrain limit line opacity

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -40,6 +40,7 @@
 
 // Color controls for the range outline
 //range_outline_color = '#0000DD';
+//range_outline_alpha = 1.0;
 //range_outline_width = 1.7;
 //range_outline_colored_by_altitude = false;
 //range_outline_dash = [5, 5]; // null - solid line, [5, 5] - dashed line with 5 pixel lines and spaces in between

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -49,6 +49,7 @@ let updateLocation = false;
 
 // Color controls for the range outline
 let range_outline_color = '#0000DD';
+let range_outline_alpha = 1.0;
 let range_outline_width = 1.7;
 let range_outline_colored_by_altitude = false;
 let range_outline_dash = null; // null - solid line, [5, 5] - dashed line with 5 pixel lines and spaces in between

--- a/html/script.js
+++ b/html/script.js
@@ -6574,7 +6574,7 @@ function drawUpintheair() {
         let color = range_outline_color;
         if (range_outline_colored_by_altitude) {
             let colorArr = altitudeColor(altitude);
-            color = 'hsl(' + colorArr[0].toFixed(0) + ',' + colorArr[1].toFixed(0) + '%,' + colorArr[2].toFixed(0) + '%)';
+            color = 'hsla(' + colorArr[0].toFixed(0) + ',' + colorArr[1].toFixed(0) + '%,' + colorArr[2].toFixed(0) + '%,' + range_outline_alpha + ')';
         }
         let outlineStyle = new ol.style.Style({
             fill: null,


### PR DESCRIPTION
My personal preference is for wider, translucent, lines terrain limit/range lines. Opacity is currently not configurable.

This pull request enables the required opacity argument to be provided via configuration (I am currently patching the files after install).

Note that the supplied default value of `1.0` is completely opaque (`0.0` being completely transparent), meaning that users who do not wish to alter the opacity value will not be affected by this change.

