### PR TITLE
Bugfix - add trailing slash to install script, enabling `jq` to be installed where it is not already present

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@ then
 fi
 
 # terminate with /
-command_package="git git/jq jq"
+command_package="git git/jq jq/"
 packages=()
 
 while read -r -d '/' CMD PKG


### PR DESCRIPTION
**Notes**
I noted recently that a fresh install to a rasperry pi / raspbian OS did not install `jq`.

- Without `jq` installed, several scripts which parse/modify json files fail to be created/updated, and `tar1090` functionality which rely on these json files fails to load/run correctly (e.g., `pTracks`)
- Failures, and error messages about `jq` being unavailable, can be observed via `journalctl`
- Manually installing `jq` resolved the errors

`jq` not being installed as part of the normal install process appears to be due to an omitted trailing slash when specifying the string to pass into `read` (the trailing token is required to denote the end of the last item).

This pull request inserts that trailing slash.

For reference/convenience, these are the relevant lines within `install.sh`.

```sh
## https://github.com/wiedehopf/tar1090/blob/994d4ee08c6c9749a156c5b1a88b83e4b85b6c73/install.sh#L32C1-L34
# terminate with /
command_package="git git/jq jq"
packages=()
```

**Test script**
To test/validate this, here is a slightly tweaked copy of the script which allows for toggling between the slash being present or not and the each branch of the `if` to be printed to the console.

```sh
# terminate with /
command_package="git git/jq jq"
#command_package="git git/jq jq/"
packages=()

while read -r -d '/' CMD PKG
do
    if ! command -v "$CMD" &>/dev/null
    then
        echo "command $CMD not found, will try to install package $PKG"
        packages+=("$PKG")
    else
        echo "command $CMD found, package $PKG not required"
        true
    fi
done < <(echo "$command_package")
```

**Terminal output**
Note that without the trailing slash, `jq` is neither required nor found to be absent (meaning that it failed to be read).

```
pi@raspberry:~ $ ./script--no_trailing_slash.sh
command git found, package git not required

pi@raspberry:~ $ ./script--trailing_slash.sh
command git found, package git not required
command jq not found, will try to install package jq

pi@raspberry:~ $
```