### PR TITLE
Route burst limit

### DIFF
--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -2908,8 +2908,9 @@ PlaneObject.prototype.setFlight = function(flight) {
                 if (debugAll) {
                     console.log(`next batch to send at ${currentTime}:`, g.route_check_array);
                 }
-                var route_check_array = g.route_check_array;
-                g.route_check_array = [];
+                // grab up to the first 100 callsigns and leave the rest for later
+                var route_check_array = g.route_check_array.slice(0,100);
+                g.route_check_array = g.route_check_array.slice(100);
 
                 jQuery.ajax({
                     type: "POST",

--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -2903,7 +2903,7 @@ PlaneObject.prototype.setFlight = function(flight) {
     if (useRouteAPI) {
         // check if it's time to send a batch of request to the API server
         if (currentTime > g.route_cache_timer) {
-            g.route_cache_timer = currentTime + 10;
+            g.route_cache_timer = currentTime + 1;
             if (g.route_check_array.length > 0) {
                 if (debugAll) {
                     console.log(`next batch to send at ${currentTime}:`, g.route_check_array);

--- a/html/script.js
+++ b/html/script.js
@@ -9,7 +9,7 @@ g.planes        = {};
 g.planesOrdered = [];
 g.route_cache = [];
 g.route_check_array = [];
-g.route_cache_timer = new Date().getTime() / 1000 + 5; // 5 seconds from now
+g.route_cache_timer = new Date().getTime() / 1000 + 1; // one second from now
 
 // Define our global variables
 let tabHidden = false;


### PR DESCRIPTION
Working with this for a couple of weeks we noticed two issues:
- the batches became to big, especially when users zoomed out at an aggregator site and suddenly thousands of routes were requested
- the user experience wasn't great with the five and then ten second waits
This patch series limits each individual route API call to a maximum of 100 callsigns and in return allows those calls once every second. This reduces the burst load on the route API server and improves the user experience.
The code has been tested on a production server :)
Thanks to Katia for the idea and the testing.