### PR TITLE
add configurable link back to a config page

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -222,6 +222,14 @@ BingMapsAPIKey = null;
 // Don't display any TIS-B planes
 // filterTISB = false;
 
+// image configuration link (back to a webUI for feeder setup)
+// if the link is supposed to point to the same host that tar1090
+// is running on the token 'HOSTNAME' (without quotes) in the Link
+// text will be replaced with the current hostname at runtime
+//
+// imageConfigLink = "";
+// imageConfigText = "";
+
 //flightawareLinks = false;
 //shareBaseUrl = 'https://globe.adsbexchange.com/';
 // planespottersLinks = false;

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -238,6 +238,10 @@ let uatNoTISB = false;
 // Don't display any TIS-B planes
 let filterTISB = false;
 
+// image configuration link (back to a webUI for feeder setup)
+let imageConfigLink = "";
+let imageConfigText = "";
+
 let flightawareLinks = false;
 let shareBaseUrl = false;
 let planespottersLinks = false;

--- a/html/index.html
+++ b/html/index.html
@@ -871,6 +871,13 @@
                   </div>
                 </td>
               </tr>
+              <tr id="imageConfigHeader" class="infoblock_row hidden">
+                <td style="text-align: center">
+                  <div>
+                    <span class="largeText"><a id="imageConfigLink" class="largeText" target="_blank" href="/">ADSB Feeder Image Config</a></span>
+                  </div>
+                </td>
+              </tr>
 
               <tr class="infoblock_heading">
                 <td style="text-align: right" class=link>

--- a/html/script.js
+++ b/html/script.js
@@ -1608,6 +1608,13 @@ jQuery('#selected_altitude_geom1')
             return;
         }
     }
+    if (imageConfigLink != "") {
+        let host = window.location).hostname;
+        let configLink = imageConfigLink.replace('HOSTNAME', host);
+        jQuery('#imageConfigLink').attr('href',configLink)
+        jQuery('#imageConfigLink').text(imageConfigText)
+        jQuery('#imageConfigHeader').show();
+    }
 }
 
 function initLegend(colors) {


### PR DESCRIPTION
This allows an obvious way from the map display to go back to a web UI that can configure a feeder setup.
Off by default.