### PR TITLE
Update layers.js to add support for FAA charts 

### DIFF
--- a/html/layers.js
+++ b/html/layers.js
@@ -334,6 +334,48 @@ function createBaseLayers() {
         }));
     }
 
+    if (1) {
+      us.push(new ol.layer.Tile({
+	      source: new ol.source.XYZ({
+		      url: "https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/VFR_Sectional/MapServer/tile/{z}/{y}/{x}",
+		      attributions: 'Tiles courtesy of <a href="http://tiles.arcgis.com/">arcgis.com</a>'
+	      }),
+	      name: 'VFR_Sectional',
+	      title: 'VFR Sectional Chart',
+	      type: 'base'
+      }));
+
+      us.push(new ol.layer.Tile({
+        source: new ol.source.XYZ({
+          url: "https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/VFR_Terminal/MapServer/tile/{z}/{y}/{x}",
+          attributions: 'Tiles courtesy of <a href="http://tiles.arcgis.com/">arcgis.com</a>'
+        }),
+        name: 'VFR_Terminal',
+        title: 'VFR Terminal Chart',
+        type: 'base'
+      }));
+
+      us.push(new ol.layer.Tile({
+	      source: new ol.source.XYZ({
+		      url: "https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/IFR_AreaLow/MapServer/tile/{z}/{y}/{x}",
+		      attributions: 'Tiles courtesy of <a href="http://tiles.arcgis.com/">arcgis.com</a>'
+	      }),
+	      name: 'IFR_AreaLow',
+	      title: 'IRF Enroute Chart Low',
+	      type: 'base'
+      }));
+
+      us.push(new ol.layer.Tile({
+	      source: new ol.source.XYZ({
+		      url: "https://tiles.arcgis.com/tiles/ssFJjBXIUyZDrSYZ/arcgis/rest/services/IFR_High/MapServer/tile/{z}/{y}/{x}",
+		      attributions: 'Tiles courtesy of <a href="http://tiles.arcgis.com/">arcgis.com</a>'
+	      }),
+	      name: 'IFR_High',
+	      title: 'IRF Enroute Chart High',
+	      type: 'base'
+      }));
+    }
+
 /*     if (ChartBundleLayers) {
 
         let chartbundleTypesDirect = {


### PR DESCRIPTION
Adds support for FAA VFR Sectional, VFR Terminal, IFR Low, and IFR High charts from official FAA chart server. This restores most of the charts previously provided through chartbundle.