### PR TITLE
Add support for Mapbox vector layers

### DIFF
--- a/html/config.js
+++ b/html/config.js
@@ -223,6 +223,15 @@ ColorByAlt = {
 //
 BingMapsAPIKey = null;
 
+// Provide a Mapbox API key here to enable the Mapbox vector layers.
+// You can obtain a free key (with usage limits) at
+// https://www.mapbox.com/
+//
+// Be sure to quote your key:
+//   MapboxAPIKey = "your key here";
+//
+MapboxAPIKey = null;
+
 // This determines what is up, default is north (0 degrees)
 //mapOrientation = 0;
 

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -235,6 +235,15 @@ let ChartBundleLayers = true;
 //
 let BingMapsAPIKey = null;
 
+// Provide a Mapbox API key here to enable the Mapbox vector layers.
+// You can obtain a free key (with usage limits) at
+// https://www.mapbox.com/
+//
+// Be sure to quote your key:
+//   MapboxAPIKey = "your key here";
+//
+let MapboxAPIKey = null;
+
 let pf_data = ["chunks/pf.json"]
 
 let mapOrientation = 0; // This determines what is up, normally north (0 degrees)

--- a/html/layers.js
+++ b/html/layers.js
@@ -334,6 +334,48 @@ function createBaseLayers() {
         }));
     }
 
+    if (loStore['mapboxKey'] != undefined)
+        MapboxAPIKey = loStore['mapboxKey'];
+
+    if (MapboxAPIKey) {
+        world.push(new ol.MapboxVectorLayer({
+            styleUrl: 'mapbox://styles/mapbox/streets-v10',
+            accessToken: MapboxAPIKey,
+            properties: {
+                name: 'mapbox_streets',
+                title: 'Mapbox Streets',
+                type: 'base',
+            },
+        }));
+        world.push(new ol.MapboxVectorLayer({
+            styleUrl: 'mapbox://styles/mapbox/light-v11',
+            accessToken: MapboxAPIKey,
+            properties: {
+                name: 'mapbox_light',
+                title: 'Mapbox Light',
+                type: 'base',
+            },
+        }));
+        world.push(new ol.MapboxVectorLayer({
+            styleUrl: 'mapbox://styles/mapbox/dark-v11',
+            accessToken: MapboxAPIKey,
+            properties: {
+                name: 'mapbox_dark',
+                title: 'Mapbox Dark',
+                type: 'base',
+            },
+        }));
+        world.push(new ol.MapboxVectorLayer({
+            styleUrl: 'mapbox://styles/mapbox/outdoors-v10',
+            accessToken: MapboxAPIKey,
+            properties: {
+                name: 'mapbox_outdoors',
+                title: 'Mapbox Outdoors',
+                type: 'base',
+            },
+        }));
+    }
+
     if (1) {
         us.push(new ol.layer.Tile({
             source: new ol.source.XYZ({


### PR DESCRIPTION
This adds support for Mapbox vector layers by splitting the current `ol-custom024.js` file into separate JS files, adding the `olms.js` package which adds support for using Mapbox styles when an API key is provided. Additionally, I've added 4 map styles (default and bright are using v10 instead of the latest v12 because the rendering isn't correct.).