### PR TITLE
Consider AIS ships as being on ground

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -2104,6 +2104,7 @@ function processBoat(feature, now, last) {
     ac.type = 'ais';
     ac.gs = pr.speed;
     ac.flight = pr.callsign;
+    ac.altitude = "ground";
     ac.r = pr.shipname
     ac.seen = now - pr.last_signal;
 


### PR DESCRIPTION
Since on ground labels are only shown at higher zoom levels this makes the map much less cluttered with labels.

An alternative solution would be to find some way of not rendering overlapping labels.