### PR TITLE
Swap Shipname & Callsign

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -2152,8 +2152,8 @@ function processBoat(feature, now, last) {
 
     ac.type = 'ais';
     ac.gs = pr.speed;
-    ac.flight = pr.callsign;
-    ac.r = pr.shipname
+    ac.flight = pr.shipname;
+    ac.r = pr.callsign;
     ac.seen = now - pr.last_signal;
 
     ac.messages  = pr.count;


### PR DESCRIPTION
Thanks for adding AIS-catcher support.

Current tar1090 displays the ship's AIS callsign on the map. On aircraft, the callsign displays the flight number or registration on the map and is usable, but the AIS callsign isn't very useful.

I propose the following:

For ships, displaying the ship name on the map is more friendly and usable. This code proposes swapping _pr.shipname_ to _ac.flight_ and _pr.callsign_ to _ac.r_ -- this will make the map display similar to AIS-Catcher

Also, added a missing semicolon at the end of the ac.r statement.
<img width="1884" alt="Screenshot 2025-01-29 at 9 56 54 AM" src="https://github.com/user-attachments/assets/8af7954b-68b8-4ab6-b63f-ad0c11224ee3" />
<img width="2394" alt="Screenshot 2025-01-29 at 9 56 32 AM" src="https://github.com/user-attachments/assets/81afa1f9-691a-44e7-ada2-be50a98630c0" />
