### PR TITLE
Rebase: Ship Formatting Updates

### DIFF
--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -853,11 +853,15 @@ PlaneObject.prototype.updateIcon = function() {
         if (useRouteAPI && this.routeString)
             callsign += ' - ' + this.routeString;
 
-        if (!extendedLabels && this.dataSource == "ais") {
-            // show registration instead for ships as callsign is less useful
-            callsign = this.registration;
+        if (!extendedLabels && this.dataSource === "ais") {
+            // Show registration instead for ships, as callsign is less useful
+            if (this.routeString && this.routeString.trim() !== "") { 
+                // Only use routeString if it exists and is not empty
+                callsign = this.registration + " - " + this.routeString;
+            } else {
+                callsign = this.registration;
+            }
         }
-
         const unknown = NBSP+NBSP+"?"+NBSP+NBSP;
 
         let alt;

--- a/html/script.js
+++ b/html/script.js
@@ -2134,9 +2134,10 @@ function processAIS(data) {
 }
 
 function shortShiptype(typeNumber) {
+    if (typeNumber = 0) return "UNKN";
     if (typeNumber <= 19) return "RESE";
     if (typeNumber <= 28) return "WING";
-    if (typeNumber <= 29) return "ASAR"; //Airborne SAR
+    if (typeNumber <= 29) return "ASAR";
     if (typeNumber <= 30) return "FISH";
     if (typeNumber <= 32) return "TUG";
     if (typeNumber <= 33) return "DRED";

--- a/html/script.js
+++ b/html/script.js
@@ -2182,8 +2182,10 @@ function processBoat(feature, now, last) {
 
     ac.type = 'ais';
     ac.gs = pr.speed;
-    ac.flight = pr.callsign;
-    ac.r = pr.shipname;
+
+    // Ensure callsign / registration is not blank; if so, use MMSI instead
+    ac.flight = (pr.callsign && pr.callsign.trim() !== "") ? pr.callsign : "MMSI"+pr.mmsi;
+    ac.r = (pr.shipname && pr.shipname.trim() !== "") ? pr.shipname : "MMSI"+pr.mmsi;
     ac.seen = now - pr.last_signal;
 
     ac.messages  = pr.count;


### PR DESCRIPTION
Add destination to callsign when available to make ais extended labels look like adsb. I think at this point ship / air extended labels look fairly harmonized.

Add shiptype = 0 with value UNKN for ships that don't report a shiptype -- more likely than deliberately using a reserved value.

Replace blank callsign / registration with MMSI. Since non-ships don't have a callsign & may not have a registration, this gives them a unique identifier.