### PR TITLE
Add ship destinations to simple labels.

### DIFF
--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -854,8 +854,16 @@ PlaneObject.prototype.updateIcon = function() {
             callsign += ' - ' + this.routeString;
 
         if (!extendedLabels && this.dataSource == "ais") {
-            // show registration instead for ships as callsign is less useful
-            callsign = this.registration || this.icao;
+            // Show registration instead for ships, as callsign is less useful
+            if (this.registration) { 
+                // If registration exists, append routeString if available
+                callsign = this.routeString && this.routeString.trim() !== "" 
+                    ? this.registration + " - " + this.routeString 
+                    : this.registration;
+            } else {
+                // If registration is not available, fallback to ICAO
+                callsign = this.icao;
+            }
         }
 
         const unknown = NBSP+NBSP+"?"+NBSP+NBSP;


### PR DESCRIPTION
Add route to ais objects with valid destinations to make simple labels match aircraft.
<img width="592" alt="image" src="https://github.com/user-attachments/assets/d860f6f7-9246-4e3a-bbce-80e6d406ec83" />
