### PR TITLE
Allow maximum zoom of 20 on custom tiles

### DIFF
--- a/html/layers.js
+++ b/html/layers.js
@@ -28,7 +28,7 @@ function createBaseLayers() {
         custom_layers.push(new ol.layer.Tile({
             source: new ol.source.OSM({
                 "url" : loStore['customTiles'],
-                maxZoom: 15,
+                maxZoom: 20,
                 transition: tileTransition,
             }),
             name: 'custom_tiles',


### PR DESCRIPTION
by using the customTiles URL parameter, I see no reason to artificially limit the maximum zoom