### PR TITLE
allow host-relative link for aiscatcher_server

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -1745,7 +1745,10 @@ jQuery('#selected_altitude_geom1')
         jQuery('#imageConfigLink').text(imageConfigText)
         jQuery('#imageConfigHeader').show();
     }
-
+    if (aiscatcher_server != "") {
+        let host = window.location.hostname;
+        aiscatcher_server = aiscatcher_server.replace('HOSTNAME', host);
+    }
 
     if (hideButtons) {
         showHideButtons();


### PR DESCRIPTION
This is analog to what we do for the configLink - simply support the magic token HOSTNAME to represent the request host.

That way a reverse proxy on the system running tar1090 can allow access to geojson and icons.png regardless of where the ais_cather is running, massively simplifying configuration.