### PR TITLE
Fix copyShareLink not working in Chrome (and possibly other browsers)

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -8910,15 +8910,7 @@ shareLinkInput.hidden = true;
 document.body.appendChild(shareLinkInput);
 
 function copyShareLink() {
-    // Assign shareLinkInput the value we want to copy
-    shareLinkInput.setAttribute("value", shareLink);
-
-    // Highlight its content
-    shareLinkInput.select();
-    // Copy the highlighted text
-    document.execCommand("copy");
-    // deselect input field
-    shareLinkInput.blur();
+    navigator.clipboard.writeText(shareLink);
 
     copyLinkTime = new Date().getTime();
     copiedIcao = SelectedPlane.icao;

--- a/html/script.js
+++ b/html/script.js
@@ -8902,13 +8902,6 @@ function printTrace() {
     _printTrace(SelectedPlane.recentTrace.trace);
 }
 
-
-// Create a "hidden" input
-let shareLinkInput = document.createElement("input");
-shareLinkInput.hidden = true;
-// Append it to the body
-document.body.appendChild(shareLinkInput);
-
 function copyShareLink() {
     navigator.clipboard.writeText(shareLink);
 


### PR DESCRIPTION
The document.execCommand function is deprecated and the copyShareLink function does not work in Chrome (and possibly other browsers).

This PR changes the copyShareLink function to use the navigator.clipboard API instead and works in modern browsers.