### PR TITLE
Fixed Mapbox support

### DIFF
--- a/html/layers.js
+++ b/html/layers.js
@@ -304,7 +304,7 @@ function createBaseLayers() {
         MapboxAPIKey = loStore['mapboxKey'];
 
     if (MapboxAPIKey) {
-        world.push(new ol.MapboxVectorLayer({
+        world.push(new ol.mapboxStyle.MapboxVectorLayer({
             styleUrl: 'mapbox://styles/mapbox/streets-v10',
             accessToken: MapboxAPIKey,
             properties: {
@@ -313,7 +313,7 @@ function createBaseLayers() {
                 type: 'base',
             },
         }));
-        world.push(new ol.MapboxVectorLayer({
+        world.push(new ol.mapboxStyle.MapboxVectorLayer({
             styleUrl: 'mapbox://styles/mapbox/light-v11',
             accessToken: MapboxAPIKey,
             properties: {
@@ -322,7 +322,7 @@ function createBaseLayers() {
                 type: 'base',
             },
         }));
-        world.push(new ol.MapboxVectorLayer({
+        world.push(new ol.mapboxStyle.MapboxVectorLayer({
             styleUrl: 'mapbox://styles/mapbox/dark-v11',
             accessToken: MapboxAPIKey,
             properties: {
@@ -331,7 +331,7 @@ function createBaseLayers() {
                 type: 'base',
             },
         }));
-        world.push(new ol.MapboxVectorLayer({
+        world.push(new ol.mapboxStyle.MapboxVectorLayer({
             styleUrl: 'mapbox://styles/mapbox/outdoors-v10',
             accessToken: MapboxAPIKey,
             properties: {


### PR DESCRIPTION
On current tar1090, if a Mapbox API key is provided in the config, tar1090 fails to initialize as the constructor for MapboxVectorLayer can't be found. This is because MapboxVectorLayer is no longer under ol directly but now under ol.mapboxStyle. This PR updates the layer initialization code accordingly, thus making the Mapbox map styles work again.