### PR TITLE
Add auto-refresh timer for NOAA Radar WMS layer

### DIFF
--- a/html/layers.js
+++ b/html/layers.js
@@ -720,6 +720,12 @@ function createBaseLayers() {
             extent: naExtent,
         });
 
+        let refreshNoaaRadar = function () {
+            noaaRadarSource.refresh();
+        }
+        refreshNoaaRadar();
+        window.setInterval(refreshNoaaRadar, 5 * 60 * 1000);
+
         us.push(noaaRadar);
     }
 


### PR DESCRIPTION
## Summary

- The NOAA Radar overlay (`base_reflectivity_mosaic` from `nowcoast.noaa.gov`) was missing an auto-refresh timer
- NEXRAD (2 min) and NOAA Infrared Sat (15 min) both have `setInterval` refreshes, but NOAA Radar was loaded once and never updated
- Adds a 5-minute refresh interval using the same `source.refresh()` pattern as the NOAA Infrared Sat layer

## Change

```javascript
let refreshNoaaRadar = function () {
    noaaRadarSource.refresh();
}
refreshNoaaRadar();
window.setInterval(refreshNoaaRadar, 5 * 60 * 1000);
```