### PR TITLE
Feature: Airline lookup by callsign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+*.local*
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/html/config.js
+++ b/html/config.js
@@ -260,6 +260,9 @@ ColorByAlt = {
 // show links to various registration websites (not all countries)
 // registrationLinks = true;
 
+// enable callsign-based airline lookup from the operators database
+// airlineLookup = true;
+
 // Filter implausible positions (required speed > Mach 3.5)
 // valid values: true, false, "onlyMLAT" ("" required)
 // positionFilter = true;
@@ -284,13 +287,14 @@ ColorByAlt = {
 //squareMania = false;
 
 // Columns that have a // in front of them are shown.
-/* // remove this line to mofify columns (and the one at the end)
+/* // remove this line to modify columns (and the one at the end)
 HideCols = [
 	"#icao",
 //	"#country",
 //	"#flight",
 //	"#route",
 	"#registration",
+	"#airline",
 //	"#type",
 //	"#squawk",
 //	"#altitude",

--- a/html/defaults.js
+++ b/html/defaults.js
@@ -282,6 +282,9 @@ let planespottersLinks = false;
 // show links to various registration websites (not all countries)
 let registrationLinks = true;
 
+// enable callsign-based airline lookup from the operators database
+let airlineLookup = false;
+
 // Filter implausible positions (required speed > Mach 2.5)
 // valid values: true, false, "onlyMLAT" ("" required)
 let positionFilter = false;
@@ -312,6 +315,7 @@ let HideCols = [
 //	"#flight",
 //	"#route",
 	"#registration",
+	"#airline",
 //	"#type",
 //	"#squawk",
 //	"#altitude",

--- a/html/index.html
+++ b/html/index.html
@@ -44,6 +44,12 @@
             <div class="infoHeading"><span>Type code: </span></div>
             <div class="infoData"><span id="highlighted_icaotype">n/a</span></div>
           </div>
+          <div class="rSpacer">
+          </div>
+          <div>
+            <div class="infoHeading"><span>Airline: </span></div>
+            <div class="infoData"><span id="highlighted_airline">n/a</span></div>
+          </div>
           <div>
               <div id="routeRowHighlight" class="infoHeading"><span title="Reported flight origin and destination according to adsbdb.com">Route</span>:</div>
               <div class="infoData"><span id="highlighted_route"></span></div>

--- a/html/index.html
+++ b/html/index.html
@@ -172,6 +172,14 @@
                   </div>
                 </td>
               </tr>
+              <tr id="selected_airline_row" class="hidden">
+                <td>
+                  <div class="infoHeading">
+                    <span title="Airline/Operator name for the active callsign">Airline: </span>
+                  </div>
+                  <div class="infoData"><span id="selected_airline" title="n/a">n/a</span></div>
+                </td>
+              </tr>
               <tr>
                 <td>
                   <div class="infoHeading">

--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -136,6 +136,9 @@ PlaneObject.prototype.setNull = function() {
     this.msgs978   = 0;
     this.messageRate = 0;
     this.messageRateOld = 0;
+
+    this.airline = null;
+    this.airlineKey = null;
 };
 
 function planeCloneState(target, source) {
@@ -2796,8 +2799,34 @@ PlaneObject.prototype.setTypeFlagsReg = function(data) {
         if (this.pia)
             this.registration = null;
     }
-    if (data.r) this.registration = `${data.r}`;
+    if (data.r) {
+        const newRegistration = `${data.r}`;
+        if (newRegistration !== this.registration) {
+            this.registration = newRegistration;
+            this.clearAirlineCache();
+        }
+    }
 }
+
+PlaneObject.prototype.clearAirlineCache = function() {
+    this.airline = null;
+    this.airlineKey = null;
+};
+
+PlaneObject.prototype.getAirline = function() {
+    if (!airlineLookup || !operatorsCache || typeof lookupAirlineForCallsign !== 'function') {
+        return null;
+    }
+    const callsign = this.name || '';
+    const registration = this.registration || '';
+    const key = `${callsign}|${registration}`;
+    if (this.airlineKey === key) {
+        return this.airline;
+    }
+    this.airlineKey = key;
+    this.airline = lookupAirlineForCallsign(callsign, registration);
+    return this.airline;
+};
 
 PlaneObject.prototype.checkForDB = function(data) {
     if (!this.dbinfoLoaded && this.icao >= 'ae6620' && this.icao <= 'ae6899') {
@@ -3079,6 +3108,7 @@ function routeDoLookup() {
 }
 
 PlaneObject.prototype.setFlight = function(flight) {
+    const oldName = this.name;
     if (flight == null) {
         if (now - this.flightTs > 10 * 60) {
             this.flight = null;
@@ -3091,6 +3121,9 @@ PlaneObject.prototype.setFlight = function(flight) {
         this.flight = `${flight}`;
         this.name = this.flight.trim() || 'empty callsign';
         this.flightTs = now;
+    }
+    if (this.name !== oldName) {
+        this.clearAirlineCache();
     }
 }
 

--- a/html/script.js
+++ b/html/script.js
@@ -470,6 +470,9 @@ function fetchDone(data) {
     }
 }
 
+let operatorsCache = null;
+let operatorsCacheLoaded = false;
+
 function db_load_type_cache() {
     return jQuery.getJSON(databaseFolder + "/icao_aircraft_types2.js").done(function(typeLookupData) {
         g.type_cache = typeLookupData;
@@ -477,6 +480,69 @@ function db_load_type_cache() {
             g.planesOrdered[i].setTypeData();
         }
     });
+}
+
+function db_load_operators_cache() {
+    if (operatorsCacheLoaded) {
+        return jQuery.Deferred().resolve(operatorsCache).promise();
+    }
+    operatorsCacheLoaded = true;
+    return jQuery.getJSON(databaseFolder + "/operators.js").done(function(operatorData) {
+        operatorsCache = operatorData || {};
+    }).fail(function() {
+        operatorsCache = {};
+    });
+}
+
+function lookupAirlineForCallsign(callsign, registration) {
+    if (!airlineLookup || !operatorsCache) {
+        return null;
+    }
+    if (!callsign) {
+        return null;
+    }
+
+    // borrows approach used in FlightGazer, probably could be improved
+    let cs = callsign.replace(/\s/g, '');
+    if (cs.length < 4) {
+        return null;
+    }
+    cs = cs.toUpperCase();
+    let first4 = cs.slice(0, 4);
+    if (/^[A-Z]{4}$/.test(first4)) {
+        return null;
+    }
+    let prefix = cs.slice(0, 3);
+    if (!/^[A-Z]{3}$/.test(prefix)) {
+        return null;
+    }
+    if (registration) {
+        let regNormalized = registration.replace(/[\-\+]/g, '').toUpperCase();
+        if (regNormalized === cs) {
+            return null;
+        }
+    }
+    return operatorsCache[prefix] || null;
+}
+
+function updateSelectedAirline(selected) {
+    if (!airlineLookup) {
+        jQuery('#selected_airline_row').addClass('hidden');
+        jQuery('#selected_airline').updateText('n/a');
+        jQuery('#selected_airline').attr('title', 'Airline lookup disabled');
+        return;
+    }
+    jQuery('#selected_airline_row').removeClass('hidden');
+
+    let operatorData = lookupAirlineForCallsign(selected.name, selected.registration);
+    if (operatorData) {
+        let title = operatorData.c ? operatorData.c + (operatorData.r ? ' / ' + '"' + operatorData.r + '"' : '') : (operatorData.r || '');
+        jQuery('#selected_airline').updateText(operatorData.n || 'n/a');
+        jQuery('#selected_airline').attr('title', title || '');
+    } else {
+        jQuery('#selected_airline').updateText('n/a');
+        jQuery('#selected_airline').attr('title', 'No airline match');
+    }
 }
 
 g.afterLoadDone = false;
@@ -513,7 +579,7 @@ function afterFirstFetch() {
 
         geoMag = geoMagFactory(cof2Obj());
 
-        db_load_type_cache().always(function() {
+        jQuery.when(db_load_type_cache(), db_load_operators_cache()).always(function() {
             refresh();
         });
 
@@ -3449,6 +3515,7 @@ function refreshPhoto(selected) {
 let selCall = null;
 let selIcao = null;
 let selReg = null;
+let selAirline = null;
 
 let somethingSelected = false;
 // Refresh the detail window about the plane
@@ -3522,6 +3589,9 @@ function refreshSelected() {
             jQuery('#selected_registration').updateText("n/a");
         }
     }
+
+    updateSelectedAirline(selected);
+
     let dbFlags = "";
     if (selected.ladd)
         dbFlags += ' <a class="link" target="_blank" href="https://www.faa.gov/pilots/ladd/" rel="noreferrer">LADD</a> / ';
@@ -4019,6 +4089,17 @@ function refreshFeatures() {
         },
         html: flightawareLinks,
         text: 'Callsign' };
+    cols.airline = {
+        text: 'Airline',
+        sort: function () { sortBy('airline', compareAlpha, function(x) {
+            let operatorData = lookupAirlineForCallsign(x.name, x.registration);
+            return operatorData ? (operatorData.n || '') : '';
+        }); },
+        value: function(plane) {
+            let operatorData = lookupAirlineForCallsign(plane.name, plane.registration);
+            return operatorData ? (operatorData.n || '') : '';
+        }
+    };
     if (routeApiUrl) {
         cols.route = {
             sort: function () { sortBy('route', compareAlpha, function(x) { return x.routeColumn }); },

--- a/html/script.js
+++ b/html/script.js
@@ -4076,6 +4076,20 @@ function refreshFeatures() {
         return xf - yf;
     }
 
+    function compareAlphaCI(xa, ya) {
+        // only used by the airline column for now
+        // assumes ASCII strings from the database
+        if (xa === ya)
+            return 0;
+        xa = xa ? xa.toLowerCase() : '';
+        ya = ya ? ya.toLowerCase() : '';
+        if (xa < ya)
+            return -1;
+        if (xa > ya)
+            return 1;
+        return 0;
+    }
+
     const cols = planeMan.cols = {};
 
     cols.icao = {
@@ -4103,7 +4117,7 @@ function refreshFeatures() {
         text: 'Callsign' };
     cols.airline = {
         text: 'Airline',
-        sort: function () { sortBy('airline', compareAlpha, function(x) {
+        sort: function () { sortBy('airline', compareAlphaCI, function(x) {
             let operatorData = x.getAirline ? x.getAirline() : lookupAirlineForCallsign(x.name, x.registration);
             return operatorData ? (operatorData.n || '') : null;
         }); },

--- a/html/script.js
+++ b/html/script.js
@@ -4105,12 +4105,17 @@ function refreshFeatures() {
         text: 'Airline',
         sort: function () { sortBy('airline', compareAlpha, function(x) {
             let operatorData = x.getAirline ? x.getAirline() : lookupAirlineForCallsign(x.name, x.registration);
-            return operatorData ? (operatorData.n || '') : '';
+            return operatorData ? (operatorData.n || '') : null;
         }); },
         value: function(plane) {
             let operatorData = plane.getAirline ? plane.getAirline() : lookupAirlineForCallsign(plane.name, plane.registration);
-            return operatorData ? (operatorData.n || '') : '';
-        }
+            if (!operatorData) {
+                return '';
+            }
+            let title = operatorData.c ? operatorData.c + (operatorData.r ? ' / ' + '&quot;' + operatorData.r + '&quot;': '') : (operatorData.r || '');
+            return '<span title="' + title + '">' + (operatorData.n || '') + '</span>';
+        },
+        html: true
     };
     if (routeApiUrl) {
         cols.route = {

--- a/html/script.js
+++ b/html/script.js
@@ -534,7 +534,7 @@ function updateSelectedAirline(selected) {
     }
     jQuery('#selected_airline_row').removeClass('hidden');
 
-    let operatorData = lookupAirlineForCallsign(selected.name, selected.registration);
+    let operatorData = selected.getAirline ? selected.getAirline() : lookupAirlineForCallsign(selected.name, selected.registration);
     if (operatorData) {
         let title = operatorData.c ? operatorData.c + (operatorData.r ? ' / ' + '"' + operatorData.r + '"' : '') : (operatorData.r || '');
         jQuery('#selected_airline').updateText(operatorData.n || 'n/a');
@@ -4092,11 +4092,11 @@ function refreshFeatures() {
     cols.airline = {
         text: 'Airline',
         sort: function () { sortBy('airline', compareAlpha, function(x) {
-            let operatorData = lookupAirlineForCallsign(x.name, x.registration);
+            let operatorData = x.getAirline ? x.getAirline() : lookupAirlineForCallsign(x.name, x.registration);
             return operatorData ? (operatorData.n || '') : '';
         }); },
         value: function(plane) {
-            let operatorData = lookupAirlineForCallsign(plane.name, plane.registration);
+            let operatorData = plane.getAirline ? plane.getAirline() : lookupAirlineForCallsign(plane.name, plane.registration);
             return operatorData ? (operatorData.n || '') : '';
         }
     };

--- a/html/script.js
+++ b/html/script.js
@@ -3978,6 +3978,18 @@ function refreshHighlighted() {
         jQuery('#highlighted_registration').text("n/a");
     }
 
+    let highlightedOperator = null;
+    if (highlighted.getAirline) {
+        highlightedOperator = highlighted.getAirline();
+    } else {
+        highlightedOperator = lookupAirlineForCallsign(highlighted.name, highlighted.registration);
+    }
+    if (highlightedOperator) {
+        jQuery('#highlighted_airline').text(highlightedOperator.n || 'n/a');
+    } else {
+        jQuery('#highlighted_airline').text('n/a');
+    }
+
     jQuery('#highlighted_speed').text(format_speed_long(highlighted.gs, DisplayUnits));
 
     jQuery("#highlighted_altitude").text(format_altitude_long(adjust_baro_alt(highlighted.altitude), highlighted.vert_rate, DisplayUnits));


### PR DESCRIPTION
Adds new airline lookup by callsign with the associated UI changes. Uses the `operators.js` file that's already part of `tar1090-db` that gets pulled when running the install script, so no need for additional databases or files.

---

## Pics first

| |
| --- |
| <img width="358" height="404" alt="Screenshot 2026-05-28 145746" src="https://github.com/user-attachments/assets/c1a1b298-c4ff-4dfe-acaf-8ccfc494dc0a" /> <br>*Adds to the infoblock and also has a tooltip with the country and telephonic name* |
<img width="355" height="755" alt="Screenshot 2026-05-28 143947" src="https://github.com/user-attachments/assets/bc45bca7-9a52-4cb7-9505-8bbd74074cf2" /> <br>*Adds new column to the table* |
<img width="460" height="265" alt="Screenshot 2026-05-29 120314" src="https://github.com/user-attachments/assets/98c9645c-6505-423f-84a5-c9e821c86f79" /> <br>*Also does the same tooltip thing like how the route column does it* |
| <img width="240" height="324" alt="image" src="https://github.com/user-attachments/assets/a1b7eeb1-e205-43a7-9edb-e4f58cb65246" /> <br>*Also available in the hoverbox thing* |
| <img width="330" height="521" alt="image" src="https://github.com/user-attachments/assets/f245185b-c2d5-4393-813d-9969f7b970c2" /> <br>*Disabled by default in `defaults.js`* | 

---

## `operators.js` limitations as of this post

> [!IMPORTANT]
> See [this comparison table](https://github.com/WeegeeNumbuh1/FlightGazer-airlines-db#examples--comparison).

tl;dr **it needed a lot of cleanup** so I'm using my own database to get cleaner looking names.
<details><summary>off-topic ramblings</summary>

Maybe my database can be integrated into tar1090-db? Because imho the names used in the operators file looks like a set of basic filters and formatting was only applied to the FAA file.

</details>

<img width="292" height="95" alt="image" src="https://github.com/user-attachments/assets/d9546ad4-23d4-411b-82f1-cc38d942c812" /><br>*oof*

---
### Additional features

- Handles "registration being used as callsign" conflicts (e.x. callsign = `RPC123` vs. reg = `RP-C123`).

### Known limitations and things I didn't test

- IATA prefixes won't be handled (usually seen with ADS-C)
- Special prefixes >3 characters are also not handled
- How this affects the history feature is unknown (I don't use this feature)
  - pTracks works fine so the history feature probably is fine too
- Unknown to what extent these changes would affect aggregators that already have some kind of airline matching present if this gets merged and they rebase their forks
- The extent of which the lookup affects client-side performance is not precisely quantified, especially at the scale of aggregators, but so far with my setup that usually handles about 300 aircraft at a time I see no perceptible changes
- Existing installs will probably have to add the airline feature flag manually to their existing configs if this gets merged
  - Updating if/once this is merged won't break things since `defaults.js` has all the added elements to handle this feature

### Things that probably could be added later

- Adding airline name to the labels?
  - It's already crowded when the route feature is enabled
  - Probably can be displayed when pressing the 'O' button
- Filtering by airline
  - Can already be done just by the callsign prefix
- Further UI tweaks

### Why this feature?

I got tired of seeing airline prefixes I didn't recognize and having to look them up manually in my own database, plus, [I already figured out](https://github.com/WeegeeNumbuh1/FlightGazer/blob/fbe0322ca1754554602d2b45e9248c54ec8d9322/FlightGazer.py#L5877) how to do callsign to airline matching with my other project, so it made sense to add the feature to tar1090. Also, I didn't see anyone else suggesting or adding a feature like this so I went ahead and did it.

### Other things

First PR ever; I don't really know all the conventions with git/GitHub/branching and all that, all my own repos I just yolo it and commit to main/master lmao. Hopefully this PR is good.