### PR TITLE
AIS overlay: label ships by name and apply normal label rules to AIS targets

### DIFF
--- a/html/planeObject.js
+++ b/html/planeObject.js
@@ -843,7 +843,7 @@ PlaneObject.prototype.updateIcon = function() {
 
     if ( g.enableLabels && (!multiSelect || (multiSelect && this.selected)) &&
         (
-            (g.zoomLvl >= labelZoom && this.altitude != "ground" && this.dataSource != "ais")
+            (g.zoomLvl >= labelZoom && this.altitude != "ground")
             || (g.zoomLvl >= labelZoomGround - 2 && this.speed > 5 && !this.fakeHex)
             || (g.zoomLvl >= labelZoomGround + 0 && !this.fakeHex)
             || (g.zoomLvl >= labelZoomGround + 1)
@@ -851,13 +851,13 @@ PlaneObject.prototype.updateIcon = function() {
         )
     ) {
         let callsign = "";
-        if (this.flight && this.flight.trim() && !(this.dataSource == "ais" && !g.extendedLabels))
+        if (this.flight && this.flight.trim())
             callsign =  this.flight.trim();
         else if (this.registration)
             callsign =  'reg: ' + this.registration;
         else
             callsign =   'hex: ' + this.icao;
-        if ((useRouteAPI || this.dataSource == "ais") && this.routeString) {
+        if (useRouteAPI && this.dataSource != "ais" && this.routeString) {
             if (0 && g.extendedLabels) {
                 callsign += ' - ' + this.routeString;
             } else {

--- a/html/script.js
+++ b/html/script.js
@@ -2320,8 +2320,10 @@ function processBoat(feature, now, last) {
 
     ac.type = 'ais';
     ac.gs = pr.speed;
-    ac.flight = pr.callsign;
-    ac.r = pr.shipname;
+    // Maritime callsign is the ITU ship-station license - a registration-
+    // role identifier, not an operational one. A vessel is hailed by NAME.
+    ac.flight = pr.shipname || pr.callsign || String(pr.mmsi);
+    ac.r = pr.callsign;
     ac.seen = now - pr.last_signal;
 
     ac.messages  = pr.count;


### PR DESCRIPTION
**Problem**

With an AIS-catcher overlay configured (`aiscatcher_server`), ships never get map labels even when labels are enabled, and their callsign column in the aircraft table is blank. Vessel names only appear in the info popup.

**Cause**

`processBoat()` maps the AIS `callsign` field into `ac.flight`, which drives both map labels and the table's callsign column. In AIS, callsign is the ITU ship station license, a registration-type identifier, and it is empty on most vessels (inland workboats especially almost never program it). A vessel's working identity, what it is hailed by on marine VHF, is its name, which the code currently parks in `ac.r`. Because labels built from callsign were effectively always blank, AIS targets also ended up excluded from the basic label mode and from the airborne label zoom threshold, so even named vessels could not label at normal zoom.

**Changes**

1. `ac.flight` for AIS targets is now `shipname || callsign || String(mmsi)`, so labels and the table always have content and use the name a vessel actually goes by. `ac.r` now carries the callsign, which matches that field's registration role. This change alone also fixes the blank table column.
2. AIS targets may label at the normal `labelZoom` threshold instead of only the ground-vehicle thresholds.
3. AIS targets follow the regular labels toggle instead of requiring extended label modes.
4. The raw AIS `destination` field is no longer appended to ship labels. It is free text, frequently stale or garbled on inland vessels (e.g. `US^03XX>0V9F`), and it remains visible in the popup.

**Tested**

tar1090 v3.14.1810 with AIS-catcher v0.70 (`geojson on`) watching Ohio River traffic near Pittsburgh. Screenshot in the comment below: named vessels label by shipname (LISA MARIE, DASHIELDS_L&D), an unnamed vessel falls back to its bare MMSI (367712570), the table shows the same identities in its callsign column, and aircraft are unaffected, all at normal zoom with the standard labels toggle. Without this change, AIS targets show no labels at these zoom levels and blank callsigns in the table.

**Open questions**

- The MMSI fallback is a bare number for parity with AIS-catcher's own UI. If you prefer this to follow the `hex:` / `reg:` fallback style, happy to change it.
- If you would rather keep ships on the ground zoom threshold or keep destination in labels behind a sanitizer, I can rework; the core fix is change 1.
