### PR TITLE
Update ANAC Brazil RAB registry lookup URL

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -8725,7 +8725,7 @@ function setAutoselect() {
 function registrationLink(plane) {
     
     const countryLinks = {
-        Brazil: (reg) => `https://sistemas.anac.gov.br/aeronaves/cons_rab_resposta_en.asp?textMarca=${reg}`,
+        Brazil: (reg) => `https://aeronaves.anac.gov.br/aeronaves/cons_rab_resposta_en.asp?textMarca=${reg}`,
         Australia: (reg) => `https://www.casa.gov.au/search-centre/aircraft-register?reg=${reg.replace(/^VH-/, '')}`,
         Jamaica: (reg) => `https://www.jcaa.gov.jm/aircraft-registry/${reg}`,
         Montenegro: (reg) => `https://www.caa.me/en/registri?field_registarska_oznaka1_value=${reg}`,


### PR DESCRIPTION
The old subdomain (`sistemas.anac.gov.br`) has been replaced with `aeronaves.anac.gov.br`

<img width="1720" height="674" alt="Screenshot From 2026-07-28 15-51-18" src="https://github.com/user-attachments/assets/650ec994-aae8-42b7-a915-2cc1dfd511ab" />
